### PR TITLE
feat(lsp): enhance completion menu with kind highlighting

### DIFF
--- a/src/configs/ghostty/config
+++ b/src/configs/ghostty/config
@@ -23,6 +23,8 @@ macos-titlebar-style = tabs
 background=#000000
 background-opacity = 0.85
 background-blur = 35
+# Apply opacity+blur to cells with explicit background colors too (frosted popups)
+background-opacity-cells = true
 
 bold-is-bright = true
 cursor-opacity = .8

--- a/src/configs/ghostty/config
+++ b/src/configs/ghostty/config
@@ -22,6 +22,8 @@ confirm-close-surface = false
 macos-titlebar-style = tabs
 background=#000000
 background-opacity = 0.85
+# Native macOS 26+ glass. On older macOS the glass material is unavailable and
+# blur silently falls back — swap the two lines below for a numeric radius there.
 background-blur = macos-glass-regular
 # background-blur = 35
 # Apply opacity+blur to cells with explicit background colors too (frosted popups)

--- a/src/configs/ghostty/config
+++ b/src/configs/ghostty/config
@@ -22,8 +22,8 @@ confirm-close-surface = false
 macos-titlebar-style = tabs
 background=#000000
 background-opacity = 0.85
-# Native macOS 26 glass material — reads as frosted glass even over dark backdrops
 background-blur = macos-glass-regular
+# background-blur = 35
 # Apply opacity+blur to cells with explicit background colors too (frosted popups)
 background-opacity-cells = true
 

--- a/src/configs/ghostty/config
+++ b/src/configs/ghostty/config
@@ -22,7 +22,8 @@ confirm-close-surface = false
 macos-titlebar-style = tabs
 background=#000000
 background-opacity = 0.85
-background-blur = 35
+# Native macOS 26 glass material — reads as frosted glass even over dark backdrops
+background-blur = macos-glass-regular
 # Apply opacity+blur to cells with explicit background colors too (frosted popups)
 background-opacity-cells = true
 

--- a/src/configs/nvim/lua/colors/init.lua
+++ b/src/configs/nvim/lua/colors/init.lua
@@ -95,6 +95,10 @@ local function set_highlights()
 	hl(0, "PmenuSbar", { bg = "NONE" })
 	hl(0, "PmenuThumb", { bg = c.dim })
 	hl(0, "PmenuBorder", { fg = c.dim })
+	hl(0, "PmenuMatch", { fg = "#2AAAFF", bold = true }) -- fuzzy-matched chars (VSCode list highlight blue)
+	hl(0, "PmenuMatchSel", { fg = "#2AAAFF", bold = true })
+	hl(0, "PmenuKind", { fg = c.gray }) -- kind column fallback; LSP items get syntax colors
+	hl(0, "PmenuKindSel", { fg = c.gray })
 
 	-- Whitespace/Special
 	hl(0, "SpecialKey", { fg = c.line_nr_dim })

--- a/src/configs/nvim/lua/colors/init.lua
+++ b/src/configs/nvim/lua/colors/init.lua
@@ -89,7 +89,8 @@ local function set_highlights()
 	hl(0, "TabLineFill", { bg = "NONE" })
 	hl(0, "TabLineSel", { fg = c.white, bg = "NONE" })
 
-	-- Pmenu (completion)
+	-- Pmenu (completion) — bg stays NONE so the menu shows the terminal's own
+	-- transparent/blurred background, same as the editor
 	hl(0, "Pmenu", { fg = c.fg, bg = "NONE" })
 	hl(0, "PmenuSel", { bg = "#03395e" })
 	hl(0, "PmenuSbar", { bg = "NONE" })

--- a/src/configs/nvim/lua/colors/init.lua
+++ b/src/configs/nvim/lua/colors/init.lua
@@ -47,6 +47,8 @@ local c = {
 	-- Misc
 	white = "#ffffff",
 	dim = "#444444",
+	list_match = "#2AAAFF", -- VSCode list-highlight blue (fuzzy-matched chars)
+	list_sel_bg = "#03395e", -- selected-row background (Pmenu, NvimTree cursorline)
 }
 
 local function set_highlights()
@@ -92,14 +94,14 @@ local function set_highlights()
 	-- Pmenu (completion) — bg stays NONE so the menu shows the terminal's own
 	-- transparent/blurred background, same as the editor
 	hl(0, "Pmenu", { fg = c.fg, bg = "NONE" })
-	hl(0, "PmenuSel", { bg = "#03395e" })
+	hl(0, "PmenuSel", { bg = c.list_sel_bg })
 	hl(0, "PmenuSbar", { bg = "NONE" })
 	hl(0, "PmenuThumb", { bg = c.dim })
 	hl(0, "PmenuBorder", { fg = c.dim })
-	hl(0, "PmenuMatch", { fg = "#2AAAFF", bold = true }) -- fuzzy-matched chars (VSCode list highlight blue)
-	hl(0, "PmenuMatchSel", { fg = "#2AAAFF", bold = true })
+	hl(0, "PmenuMatch", { fg = c.list_match, bold = true }) -- fuzzy-matched chars
+	hl(0, "PmenuMatchSel", { link = "PmenuMatch" })
 	hl(0, "PmenuKind", { fg = c.gray }) -- kind column fallback; LSP items get syntax colors
-	hl(0, "PmenuKindSel", { fg = c.gray })
+	hl(0, "PmenuKindSel", { link = "PmenuKind" })
 
 	-- Whitespace/Special
 	hl(0, "SpecialKey", { fg = c.line_nr_dim })
@@ -283,7 +285,7 @@ local function set_highlights()
 	hl(0, "NvimTreeImageFile", { fg = c.fg })
 	hl(0, "NvimTreeSymlink", { fg = c.blue_green })
 	hl(0, "NvimTreeWinSeparator", { fg = c.dim, bg = "NONE" })
-	hl(0, "NvimTreeCursorLine", { bg = "#03395e" })
+	hl(0, "NvimTreeCursorLine", { bg = c.list_sel_bg })
 
 	-- GitSigns
 	hl(0, "GitSignsAdd", { fg = c.diff_add })

--- a/src/configs/nvim/lua/config/options.lua
+++ b/src/configs/nvim/lua/config/options.lua
@@ -35,7 +35,10 @@ opt.winborder = "rounded" -- Border style for floating windows
 opt.pumborder = "rounded" -- Border style for completion menu
 opt.pumheight = 10 -- Limit completion menu height
 opt.pummaxwidth = 80 -- Keep completion popups readable on long LSP labels
-opt.pumblend = 10 -- Slight transparency for popup menu
+-- pumblend blends the menu with the CODE behind it (crisp ghost text — nvim
+-- draws characters, so no blur can ever apply). The pretty transparency is the
+-- other kind: Pmenu bg=NONE showing the ghostty-blurred desktop through.
+opt.pumblend = 0
 opt.cmdheight = 0 -- Hide command line when it is not actively used
 
 -- Custom statusline for terminal buffers

--- a/src/configs/nvim/lua/plugins/lsp.lua
+++ b/src/configs/nvim/lua/plugins/lsp.lua
@@ -38,6 +38,21 @@ local kind_hl = {
 -- Keep LspAttach reload-safe; sourcing this file again replaces the old autocmd.
 local lsp_augroup = vim.api.nvim_create_augroup("custom_lsp", { clear = true })
 
+-- Give the completion docs float the same rounded border as the menu. It
+-- ignores 'winborder' and is created only after the server's docs resolve
+-- (so a CompleteChanged autocmd fires too early to see it); vim.lsp.completion
+-- creates it through this API, which is the one reliable hook.
+local complete_set = vim.api.nvim__complete_set
+if complete_set then
+	vim.api.nvim__complete_set = function(...)
+		local windata = complete_set(...)
+		if type(windata) == "table" and windata.winid and vim.api.nvim_win_is_valid(windata.winid) then
+			pcall(vim.api.nvim_win_set_config, windata.winid, { border = "rounded" })
+		end
+		return windata
+	end
+end
+
 -- Built-in completion uses Vim's popup menu. These mappings only send completion
 -- keys when the popup is visible, otherwise they fall back to the original key.
 local function pum_keymap(visible_key, fallback_key)

--- a/src/configs/nvim/lua/plugins/lsp.lua
+++ b/src/configs/nvim/lua/plugins/lsp.lua
@@ -82,9 +82,11 @@ vim.api.nvim_create_autocmd("LspAttach", {
 		if client:supports_method(methods.textDocument_completion, ev.buf) then
 			-- Autotrigger only fires on the server's trigger characters; extend
 			-- them with identifier characters so completion also pops while
-			-- typing plain words (:h lsp-autocompletion)
+			-- typing plain words (:h lsp-autocompletion). Emmet is excluded:
+			-- it already letter-triggers natively and would flood every word
+			-- with abbreviation noise.
 			local provider = client.server_capabilities.completionProvider
-			if provider then
+			if provider and client.name ~= "emmet_language_server" then
 				local triggers = {}
 				for _, char in ipairs(provider.triggerCharacters or {}) do
 					triggers[char] = true
@@ -106,6 +108,24 @@ vim.api.nvim_create_autocmd("LspAttach", {
 						kind_hlgroup = kind_hl[kind],
 						menu = "", -- drop server detail text (e.g. emmet's "Unknown Emmet Abbreviation")
 					}
+				end,
+				-- Same ordering as the default (fuzzy score, then the server's
+				-- sortText) plus an alphabetical tiebreak the default lacks:
+				-- members often share one sortText and table.sort is unstable,
+				-- which scrambles e.g. `router.` member lists.
+				cmp = function(a, b)
+					local score_a, score_b = a._fuzzy_score or 0, b._fuzzy_score or 0
+					if score_a ~= score_b then
+						return score_a > score_b
+					end
+					local item_a = vim.tbl_get(a, "user_data", "nvim", "lsp", "completion_item") or {}
+					local item_b = vim.tbl_get(b, "user_data", "nvim", "lsp", "completion_item") or {}
+					local sort_a = item_a.sortText or item_a.label or a.word
+					local sort_b = item_b.sortText or item_b.label or b.word
+					if sort_a ~= sort_b then
+						return sort_a < sort_b
+					end
+					return (item_a.label or a.word) < (item_b.label or b.word)
 				end,
 			})
 

--- a/src/configs/nvim/lua/plugins/lsp.lua
+++ b/src/configs/nvim/lua/plugins/lsp.lua
@@ -7,6 +7,34 @@ vim.diagnostic.config({
 -- Short alias so capability checks stay readable below.
 local methods = vim.lsp.protocol.Methods
 
+-- Completion menu: color the kind column like the matching syntax element.
+local kind_hl = {
+	Class = "Structure",
+	Color = "Constant",
+	Constant = "Constant",
+	Constructor = "Function",
+	Enum = "Structure",
+	EnumMember = "Constant",
+	Event = "Type",
+	Field = "Identifier",
+	File = "Directory",
+	Folder = "Directory",
+	Function = "Function",
+	Interface = "Structure",
+	Keyword = "Keyword",
+	Method = "Function",
+	Module = "Structure",
+	Operator = "Keyword",
+	Property = "Identifier",
+	Reference = "Identifier",
+	Snippet = "Special",
+	Struct = "Structure",
+	TypeParameter = "Type",
+	Unit = "Number",
+	Value = "Number",
+	Variable = "Identifier",
+}
+
 -- Keep LspAttach reload-safe; sourcing this file again replaces the old autocmd.
 local lsp_augroup = vim.api.nvim_create_augroup("custom_lsp", { clear = true })
 
@@ -52,8 +80,34 @@ vim.api.nvim_create_autocmd("LspAttach", {
 
 		-- Setup completion if client supports it
 		if client:supports_method(methods.textDocument_completion, ev.buf) then
+			-- Autotrigger only fires on the server's trigger characters; extend
+			-- them with identifier characters so completion also pops while
+			-- typing plain words (:h lsp-autocompletion)
+			local provider = client.server_capabilities.completionProvider
+			if provider then
+				local triggers = {}
+				for _, char in ipairs(provider.triggerCharacters or {}) do
+					triggers[char] = true
+				end
+				for char in ("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_"):gmatch(".") do
+					triggers[char] = true
+				end
+				provider.triggerCharacters = vim.tbl_keys(triggers)
+			end
+
 			-- Enable LSP completion
-			vim.lsp.completion.enable(true, client.id, ev.buf, { autotrigger = true })
+			vim.lsp.completion.enable(true, client.id, ev.buf, {
+				autotrigger = true,
+				convert = function(item)
+					local kind = vim.lsp.protocol.CompletionItemKind[item.kind] or ""
+					return {
+						abbr = item.label:gsub("%b()", ""),
+						kind = kind,
+						kind_hlgroup = kind_hl[kind],
+						menu = "", -- drop server detail text (e.g. emmet's "Unknown Emmet Abbreviation")
+					}
+				end,
+			})
 
 			-- Completion keymaps
 			vim.keymap.set("i", "<C-k>", pum_keymap("<C-p>", "<C-k>"), {

--- a/src/configs/nvim/lua/plugins/lsp.lua
+++ b/src/configs/nvim/lua/plugins/lsp.lua
@@ -8,9 +8,11 @@ vim.diagnostic.config({
 local methods = vim.lsp.protocol.Methods
 
 -- Completion menu: color the kind column like the matching syntax element.
+-- No Color entry on purpose: the runtime renders Color items as a swatch tinted
+-- with the actual color (an auto-created @lsp.color.<hex> group), and leaving
+-- kind_hlgroup unset here lets that survive.
 local kind_hl = {
 	Class = "Structure",
-	Color = "Constant",
 	Constant = "Constant",
 	Constructor = "Function",
 	Enum = "Structure",
@@ -41,12 +43,17 @@ local lsp_augroup = vim.api.nvim_create_augroup("custom_lsp", { clear = true })
 -- Give the completion docs float the same rounded border as the menu. It
 -- ignores 'winborder' and is created only after the server's docs resolve
 -- (so a CompleteChanged autocmd fires too early to see it); vim.lsp.completion
--- creates it through this API, which is the one reliable hook.
-local complete_set = vim.api.nvim__complete_set
+-- creates it through this API, which is the one reliable hook. There is no
+-- public option yet — track neovim/neovim#38248 and delete this when it lands.
+--
+-- Stash the untouched original so re-sourcing this file rewraps it instead of
+-- stacking a new wrapper on the previous one each time.
+_G.__orig_complete_set = _G.__orig_complete_set or vim.api.nvim__complete_set
+local complete_set = _G.__orig_complete_set
 if complete_set then
 	vim.api.nvim__complete_set = function(...)
 		local windata = complete_set(...)
-		if type(windata) == "table" and windata.winid and vim.api.nvim_win_is_valid(windata.winid) then
+		if type(windata) == "table" and windata.winid then
 			pcall(vim.api.nvim_win_set_config, windata.winid, { border = "rounded" })
 		end
 		return windata
@@ -116,25 +123,46 @@ vim.api.nvim_create_autocmd("LspAttach", {
 			vim.lsp.completion.enable(true, client.id, ev.buf, {
 				autotrigger = true,
 				convert = function(item)
+					-- Only override kind_hlgroup (not kind): omitting kind lets the
+					-- runtime's default through, including the color swatch for Color
+					-- items. tbl_extend keeps our keys and fills the rest from default.
 					local kind = vim.lsp.protocol.CompletionItemKind[item.kind] or ""
-					return {
-						abbr = item.label:gsub("%b()", ""),
-						kind = kind,
-						kind_hlgroup = kind_hl[kind],
-						menu = "", -- drop server detail text (e.g. emmet's "Unknown Emmet Abbreviation")
-					}
+					local converted = { kind_hlgroup = kind_hl[kind] }
+
+					-- Strip signature parens only when present (skip the pattern
+					-- engine for the common paren-free label).
+					if item.label:find("(", 1, true) then
+						converted.abbr = item.label:gsub("%b()", "")
+					end
+
+					-- Blank only emmet's noise ("... Emmet Abbreviation"); every other
+					-- server keeps its detail column (e.g. TS auto-import source).
+					local detail = vim.tbl_get(item, "labelDetails", "description") or item.detail
+					if detail and detail:find("Emmet Abbreviation") then
+						converted.menu = ""
+					end
+
+					return converted
 				end,
-				-- Same ordering as the default (fuzzy score, then the server's
-				-- sortText) plus an alphabetical tiebreak the default lacks:
-				-- members often share one sortText and table.sort is unstable,
-				-- which scrambles e.g. `router.` member lists.
+				-- Mirrors the runtime default sort (nvim runtime
+				-- lua/vim/lsp/completion.lua, compare_by_sortText_and_label): fuzzy
+				-- score desc, then the server's sortText. Adds the alphabetical
+				-- tiebreak the default lacks, so member lists like `router.` (which
+				-- share one sortText, and table.sort is unstable) stop coming out in
+				-- random order. `_fuzzy_score` is an internal field only fresh
+				-- candidates carry; items carried over from another server's open
+				-- menu sort by sortText/label alone (acceptable — rare and stable).
 				cmp = function(a, b)
 					local score_a, score_b = a._fuzzy_score or 0, b._fuzzy_score or 0
 					if score_a ~= score_b then
 						return score_a > score_b
 					end
-					local item_a = vim.tbl_get(a, "user_data", "nvim", "lsp", "completion_item") or {}
-					local item_b = vim.tbl_get(b, "user_data", "nvim", "lsp", "completion_item") or {}
+					-- user_data survives the completion round-trip; index it directly
+					-- rather than via vim.tbl_get, which is called O(n log n) times.
+					local lsp_a = a.user_data and a.user_data.nvim and a.user_data.nvim.lsp
+					local lsp_b = b.user_data and b.user_data.nvim and b.user_data.nvim.lsp
+					local item_a = lsp_a and lsp_a.completion_item or {}
+					local item_b = lsp_b and lsp_b.completion_item or {}
 					local sort_a = item_a.sortText or item_a.label or a.word
 					local sort_b = item_b.sortText or item_b.label or b.word
 					if sort_a ~= sort_b then

--- a/src/configs/nvim/nvim-pack-lock.json
+++ b/src/configs/nvim/nvim-pack-lock.json
@@ -27,10 +27,6 @@
     "nvim-treesitter": {
       "rev": "4916d6592ede8c07973490d9322f187e07dfefac",
       "src": "https://github.com/nvim-treesitter/nvim-treesitter"
-    },
-    "plenary.nvim": {
-      "rev": "74b06c6c75e4eeb3108ec01852001636d85a932b",
-      "src": "https://github.com/nvim-lua/plenary.nvim"
     }
   }
 }


### PR DESCRIPTION
Improves Neovim's native LSP completion (0.12 `vim.lsp.completion`) to VS Code parity — better triggering, cleaner menu, correct sorting — and makes the popups play nicely with a transparent/blurred Ghostty setup. No completion plugins added; everything rides on native APIs.

## Completion behavior (`lua/plugins/lsp.lua`)

- **Complete as you type words.** Autotrigger only fires on each server's declared trigger characters, so in mixed buffers only emmet (which letter-triggers) ever responded while typing identifiers — the menu was 100% emmet noise. Each server's `triggerCharacters` is now extended with `a-z A-Z _` (the documented approach, `:h lsp-autocompletion`), so vtsls/html/gopls/etc. all respond while typing plain words.
- **Emmet is excluded from that extension.** Its native triggers are the actual abbreviation syntax (`>`, `+`, `.`, `!`, `*`, …), so it now only pops for real emmet input instead of flooding every word. Manual `<C-Space>` still queries it.
- **Cleaner menu items** via `convert`: kind names ("Function", "Variable", …) colored through theme syntax groups (`kind_hl` map), and `(...)` stripped from labels when present. Color items keep the runtime's native color-preview swatch (only `kind_hlgroup` is overridden, never `kind`). The server detail column is preserved for real servers (e.g. TypeScript auto-import source); only emmet's "Unknown Emmet Abbreviation" noise is blanked.
- **VS Code-consistent sorting** via `cmp`: mirrors the runtime default (fuzzy score, then server `sortText`) plus an alphabetical tiebreak the default lacks — member lists like `router.` share one `sortText`, and Lua's unstable `table.sort` was scrambling ties. Reads `user_data` directly (avoids per-comparison `vim.tbl_get` walks); the `_fuzzy_score` dependency and the carried-over-item caveat are documented inline.
- **Rounded border on the completion docs float**, matching the menu. The float ignores `winborder` and is created only after the server's docs resolve, so the only reliable hook is wrapping `nvim__complete_set` (experimental API, guarded with `pcall`). The original is stashed in `_G` so re-sourcing the file rewraps it rather than stacking wrappers. Upstream feature request for a real option: neovim/neovim#38248 — delete the hook when that lands.

## Popup transparency (`options.lua`, `colors/init.lua`, ghostty `config`)

- `pumblend = 0`: pumblend blends the *buffer text* into the menu as crisp ghost characters that no blur can ever affect. The desired transparency comes from the other path: `Pmenu` bg stays `NONE`, showing the ghostty-blurred desktop through the menu like the rest of the editor.
- New highlight groups: `PmenuMatch` (fuzzy-matched chars in VS Code list-highlight blue) and `PmenuKind` (gray fallback for the kind column), with `PmenuMatchSel`/`PmenuKindSel` linking to them. Their colors live in the palette table (`list_match`, `list_sel_bg`).
- Ghostty: `background-opacity-cells = true` so cells with explicit background colors respect window opacity/blur instead of rendering opaque — this is what previously made the menu look like a solid black slab. `background-blur` uses the native macOS 26 `macos-glass-regular` material, with a documented numeric fallback for older macOS.

## Misc

- `nvim-pack-lock.json`: plenary.nvim removed — nothing in the config uses it (diffview-plus has its own job/async lib; the only other references are an optional debug logger in nvim-autopairs and a pcall-guarded filetype fallback in fff.nvim that falls through to `vim.filetype.match()`).

## Code review

An 8-angle review pass (correctness, removed-behavior, cross-file, reuse, simplification, efficiency, altitude, conventions) ran against the diff and its findings are folded in above — notably the detail-column and color-swatch regressions, the reload-unsafe wrapper, and the sort-comparator robustness. Efficiency verdict: as-you-type triggering is **not** flooding servers (the runtime debounces at 25ms and skips re-requests while the menu is complete).
